### PR TITLE
BCE-6488: update all dasel statements for bools

### DIFF
--- a/notaryd/docker-entrypoint.sh
+++ b/notaryd/docker-entrypoint.sh
@@ -34,17 +34,17 @@ if [ "${NETWORK}" = "ledger-mainnet-1" ]; then
   dasel put -f /cosmos/config/app.toml -v $ETH_RPC_URL evm.mainnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x01" evm.mainnet.chain_id
   dasel put -f /cosmos/config/app.toml -v 65 evm.mainnet.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.mainnet.enabled
-  
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.mainnet.enabled
+
   dasel put -f /cosmos/config/app.toml -v $BSC_RPC_URL evm.bsc.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x38" evm.bsc.chain_id
   dasel put -f /cosmos/config/app.toml -v 15 evm.bsc.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.bsc.enabled
-  
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.bsc.enabled
+
   dasel put -f /cosmos/config/app.toml -v $BASE_RPC_URL evm.base.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x2105" evm.base.chain_id
   dasel put -f /cosmos/config/app.toml -v 72 evm.base.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.base.enabled
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.base.enabled
 
   dasel put -f /cosmos/config/app.toml -v $SUI_RPC_URL sui.mainnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x35834a8a" sui.mainnet.chain_id
@@ -53,12 +53,12 @@ if [ "${NETWORK}" = "ledger-mainnet-1" ]; then
   dasel put -f /cosmos/config/app.toml -v $SONIC_RPC_URL evm.sonic.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x92" evm.sonic.chain_id
   dasel put -f /cosmos/config/app.toml -v 72 evm.sonic.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.sonic.enabled
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.sonic.enabled
 
   dasel put -f /cosmos/config/app.toml -v $KATANA_RPC_URL evm.katana.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0xb67d2" evm.katana.chain_id
   dasel put -f /cosmos/config/app.toml -v 3600 evm.katana.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.katana.enabled
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.katana.enabled
   dasel put -f /cosmos/config/app.toml -v "0x00000000000000000000000000000000000000000000000000000000000b67d2" katana.chain_id
   dasel put -f /cosmos/config/app.toml -v "0xB0F70C0bD6FD87dbEb7C10dC692a2a6106817072" katana.native_lbtc_address
 else
@@ -66,17 +66,17 @@ else
   dasel put -f /cosmos/config/app.toml -v $ETH_RPC_URL evm.holesky.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x4268" evm.holesky.chain_id
   dasel put -f /cosmos/config/app.toml -v 65 evm.holesky.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.holesky.enabled
-  
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.holesky.enabled
+
   dasel put -f /cosmos/config/app.toml -v $BSC_RPC_URL evm.bsc_testnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x61" evm.bsc_testnet.chain_id
   dasel put -f /cosmos/config/app.toml -v 15 evm.bsc_testnet.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.bsc_testnet.enabled
-  
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.bsc_testnet.enabled
+
   dasel put -f /cosmos/config/app.toml -v $BASE_RPC_URL evm.base_sepolia.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x014a34" evm.base_sepolia.chain_id
   dasel put -f /cosmos/config/app.toml -v 72 evm.base_sepolia.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.base_sepolia.enabled
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.base_sepolia.enabled
 
   dasel put -f /cosmos/config/app.toml -v $SUI_RPC_URL sui.testnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x4c78adac" sui.testnet.chain_id
@@ -85,17 +85,17 @@ else
   dasel put -f /cosmos/config/app.toml -v $SONIC_RPC_URL evm.sonic_testnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0xdede" evm.sonic_testnet.chain_id
   dasel put -f /cosmos/config/app.toml -v 72 evm.sonic_testnet.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.sonic_testnet.enabled
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.sonic_testnet.enabled
 
   dasel put -f /cosmos/config/app.toml -v $INK_RPC_URL evm.ink_sepolia.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0xba5ed" evm.ink_sepolia.chain_id
   dasel put -f /cosmos/config/app.toml -v 1800 evm.ink_sepolia.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.ink_sepolia.enabled
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.ink_sepolia.enabled
 
   dasel put -f /cosmos/config/app.toml -v $KATANA_RPC_URL evm.katana_testnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x1F977" evm.katana_testnet.chain_id
   dasel put -f /cosmos/config/app.toml -v 3600 evm.katana_testnet.required_confirmations
-  dasel put -f /cosmos/config/app.toml -v true evm.katana_testnet.enabled
+  dasel put -f /cosmos/config/app.toml -v true -t bool evm.katana_testnet.enabled
   dasel put -f /cosmos/config/app.toml -v "0x000000000000000000000000000000000000000000000000000000000001F977" katana.chain_id
   dasel put -f /cosmos/config/app.toml -v "0x20eA7b8ABb4B583788F1DFC738C709a2d9675681" katana.native_lbtc_address
 
@@ -104,7 +104,7 @@ else
 
   dasel put -f /cosmos/config/app.toml -v http://ledgerd:26657 cosmos.ledger_testnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "ledger-testnet-1" cosmos.ledger_testnet.chain_id
-  dasel put -f /cosmos/config/app.toml -v true cosmos.ledger_testnet.enabled
+  dasel put -f /cosmos/config/app.toml -v true -t bool cosmos.ledger_testnet.enabled
 fi
 
 # Word splitting is desired for the command line parameters


### PR DESCRIPTION
updating all dasel bool replacement statements to have the `-t bool` flag so they are set correctly in the config

