### PR TITLE
feat: BCE-11413 - switch Sui testnet notaryd config to gRPC

### DIFF
--- a/notaryd/docker-entrypoint.sh
+++ b/notaryd/docker-entrypoint.sh
@@ -125,9 +125,10 @@ else
   dasel put -f /cosmos/config/app.toml -v 72 evm.base_sepolia.required_confirmations
   dasel put -f /cosmos/config/app.toml -v true -t bool evm.base_sepolia.enabled
 
-  dasel put -f /cosmos/config/app.toml -v $SUI_RPC_URL sui.testnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x4c78adac" sui.testnet.chain_id
-  dasel put -f /cosmos/config/app.toml -v $SUI_PACKAGE_ID sui.testnet.package_id
+  dasel put -f /cosmos/config/app.toml -v "grpc" sui.testnet.rpc_type
+  dasel put -f /cosmos/config/app.toml -v $SUI_RPC_URL sui.testnet.grpc_url
+  dasel put -f /cosmos/config/app.toml -v "0x50454d0b0fbad1288a6ab74f2e8ce0905a3317870673ab7787ebcf6f322b45fa" sui.testnet.treasury_unstake_package_id
 
   dasel put -f /cosmos/config/app.toml -v $SONIC_RPC_URL evm.sonic_testnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0xdede" evm.sonic_testnet.chain_id


### PR DESCRIPTION
## What
- Switch `notaryd` testnet `[sui.testnet]` config from JSON-RPC to gRPC (`rpc_type = "grpc"`, `rpc_url` → `grpc_url`) per the v2.3.0 upgrade
- Add `treasury_unstake_package_id` for Sui testnet; keep `chain_id`
- Note: `SUI_RPC_URL` is now a gRPC `host:port` (e.g. `fullnode.testnet.sui.io:443`), and `SUI_PACKAGE_ID` is now unused on testnet

### Ticket
[BCE-11413](https://galaxydig.atlassian.net/browse/BCE-11413)
