### PR TITLE
BCE-11461 notaryd: switch Sui mainnet config to the v2.3.0 schema

### DIFF
--- a/notaryd/docker-entrypoint.sh
+++ b/notaryd/docker-entrypoint.sh
@@ -48,9 +48,10 @@ if [ "${NETWORK}" = "ledger-mainnet-1" ]; then
   dasel put -f /cosmos/config/app.toml -v 72 evm.base.required_confirmations
   dasel put -f /cosmos/config/app.toml -v true -t bool evm.base.enabled
 
-  dasel put -f /cosmos/config/app.toml -v $SUI_RPC_URL sui.mainnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x35834a8a" sui.mainnet.chain_id
-  dasel put -f /cosmos/config/app.toml -v $SUI_PACKAGE_ID sui.mainnet.package_id
+  dasel put -f /cosmos/config/app.toml -v "rpc" sui.mainnet.rpc_type
+  dasel put -f /cosmos/config/app.toml -v $SUI_RPC_URL sui.mainnet.rpc_url
+  dasel put -f /cosmos/config/app.toml -v "0xe31c914f63d971b7a1e7c16e482e98879d0ba906f15802509b093a78485ec9b2" sui.mainnet.treasury_unstake_package_id
 
   dasel put -f /cosmos/config/app.toml -v $SONIC_RPC_URL evm.sonic.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0x92" evm.sonic.chain_id


### PR DESCRIPTION
## What

Mainnet counterpart to #18. Ledger/notary **v2.3.0** replaces the `[sui.mainnet]` `package_id` key with `rpc_type` and `treasury_unstake_package_id`:

- drop `sui.mainnet.package_id`
- add `rpc_type = "rpc"`
- add `treasury_unstake_package_id = 0xe31c914f63d971b7a1e7c16e482e98879d0ba906f15802509b093a78485ec9b2`
- `rpc_url` still comes from `SUI_RPC_URL`; `SUI_PACKAGE_ID` is now unused (same as testnet after #18)

## Why JSON-RPC and not gRPC

#18 moved testnet to `rpc_type = "grpc"` against `fullnode.testnet.sui.io:443`. Mainnet can't follow directly — our `SUI_RPC_URL` is a QuickNode endpoint that authenticates with a token in the URL path:

- `…quiknode.pro/<token>/sui.rpc.v2.LedgerService/GetServiceInfo` → `grpc-status: 0`
- same request without the token → `HTTP/2 401`

notaryd v2.3.0 links `google.golang.org/grpc@v1.75.0` and speaks native `sui.rpc.v2.*`. grpc-go takes a `host:port` resolver target and composes method URIs from the root, so there is no way to carry the `/<token>` prefix, and no Sui-side header/api-key option in the binary. Lombard's upgrade notes explicitly support `rpc_type = "rpc"` for providers not yet on gRPC.

## Testing

- `bash -n notaryd/docker-entrypoint.sh` passes
- QuickNode mainnet JSON-RPC verified from the validator: `sui_getChainIdentifier` → `35834a8a`, matching the configured `chain_id 0x35834a8a`
- To be applied post-halt (block 9070738, ~2026-08-06 11:00 UTC): rebuild notaryd with `NOTARYD_VERSION=v2.3.0` and confirm `[sui.mainnet]` in `app.toml` shows `rpc_type = 'rpc'` plus the new `treasury_unstake_package_id`

## Ticket
https://galaxydig.atlassian.net/browse/BCE-11461
