### PR TITLE
BCE-11461 fix(notaryd): sui.mainnet.rpc_type must be "json", not "rpc"

### DIFF
--- a/notaryd/docker-entrypoint.sh
+++ b/notaryd/docker-entrypoint.sh
@@ -49,7 +49,7 @@ if [ "${NETWORK}" = "ledger-mainnet-1" ]; then
   dasel put -f /cosmos/config/app.toml -v true -t bool evm.base.enabled
 
   dasel put -f /cosmos/config/app.toml -v "0x35834a8a" sui.mainnet.chain_id
-  dasel put -f /cosmos/config/app.toml -v "rpc" sui.mainnet.rpc_type
+  dasel put -f /cosmos/config/app.toml -v "json" sui.mainnet.rpc_type
   dasel put -f /cosmos/config/app.toml -v $SUI_RPC_URL sui.mainnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "0xe31c914f63d971b7a1e7c16e482e98879d0ba906f15802509b093a78485ec9b2" sui.mainnet.treasury_unstake_package_id
 


### PR DESCRIPTION
## What

One-line follow-up to #19: `sui.mainnet.rpc_type` → `"json"`.

## Why

The v2.3.0 upgrade notice (and BCE-11461) specify `rpc_type = "rpc"` for operators whose Sui provider hasn't migrated to gRPC. notaryd v2.3.0 rejects that value and panics at startup:

```
panic: failed to create verifier: failed to create sui fetcher: invalid rpc_type="rpc": must be "grpc" or "json"
```

The accepted values are **`grpc`** and **`json`** — `rpc` is not one of them.

Hit on mainnet immediately after the block 9070738 halt: ledgerd swapped to v2.3.0 cleanly, then notaryd restart-looped on this panic. Patched on the host and notaryd came up clean, keeping the existing QuickNode JSON-RPC endpoint:

```toml
[sui.mainnet]
  chain_id = '0x35834a8a'
  rpc_type = 'json'
  rpc_url = 'https://…quiknode.pro/…'
  treasury_unstake_package_id = '0xe31c914f63d971b7a1e7c16e482e98879d0ba906f15802509b093a78485ec9b2'
```

Testnet is unaffected — it uses `rpc_type = "grpc"` (#18).

Worth flagging upstream to Lombard: any operator following the notice with a JSON-RPC provider will hit the same panic.

## Testing

- `bash -n notaryd/docker-entrypoint.sh` passes
- Applied on `alpa-use1-bci-prod-lombard-mainnet-validator-dr-0`: notaryd `v2.3.0` up with no panics, `node is synced`, `notary already registered`; validator `BOND_STATUS_BONDED`, `jailed=false`, signing (`block_id_flag=2`)

## Ticket

https://galaxydig.atlassian.net/browse/BCE-11461

🤖 Generated with [Claude Code](https://claude.com/claude-code)