### PR TITLE
feat: BCE-11686 - add starknet mainnet config to notaryd

### DIFF
--- a/notaryd/docker-entrypoint.sh
+++ b/notaryd/docker-entrypoint.sh
@@ -112,6 +112,10 @@ if [ "${NETWORK}" = "ledger-mainnet-1" ]; then
   dasel put -f /cosmos/config/app.toml -v $SOLANA_RPC_URL solana.mainnet.rpc_url
   dasel put -f /cosmos/config/app.toml -v "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d" solana.mainnet.genesis_hash
 
+  dasel put -f /cosmos/config/app.toml -v "$STARKNET_RPC_URL" starknet.mainnet.rpc_url
+  dasel put -f /cosmos/config/app.toml -v "SN_MAIN" starknet.mainnet.chain_id
+  dasel put -f /cosmos/config/app.toml -v "10s" starknet.mainnet.timeout
+
 else
   # Testnet config.
   dasel put -f /cosmos/config/app.toml -v $ETH_RPC_URL evm.holesky.rpc_url


### PR DESCRIPTION
## What
- add `starknet.mainnet` (chain_id `SN_MAIN`, 10s timeout) to the notaryd mainnet config; only `starknet.sepolia` existed before
- reuses the existing `STARKNET_RPC_URL` env var, already passed through `notaryd.yml` and present in `default.env` — operators set it in `.env` on mainnet hosts

### Ticket
[BCE-11686](https://galaxydig.atlassian.net/browse/BCE-11686)

🤖 Generated with [Claude Code](https://claude.com/claude-code)